### PR TITLE
Use HTTPS instead of HTTP for API calls

### DIFF
--- a/pastebin_python/pastebin_constants.py
+++ b/pastebin_python/pastebin_constants.py
@@ -5,7 +5,7 @@
 .. moduleauthor:: Ferdinand Silva <ferdinandsilva@ferdinandsilva.com>
 
 """
-PASTEBIN_URL = "http://pastebin.com/" #: The pastebin.com base url
+PASTEBIN_URL = "https://pastebin.com/" #: The pastebin.com base url
 PASTEBIN_RAW_URL = "%s%s" % (PASTEBIN_URL, "raw.php?i=%s")
 PASTEBIN_API_URL = "%s%s" % (PASTEBIN_URL, "api/") #: The pastebin.com API base URL
 PASTEBIN_API_POST_URL = "%s%s" % (PASTEBIN_API_URL, "api_post.php") #: The pastebin.com API POST URL


### PR DESCRIPTION
Using an HTTP URL for the API yields a 405 error. For instance, when attempting to paste a file
```
api = PastebinPython(api_dev_key=API_DEV_KEY)
api.createPasteFromFile(FILE_NAME)
```
We get the following error
```
pastebin_python.pastebin_exceptions.PastebinFileException: HTTP Error 405: Method Not Allowed
```
Using HTTPS instead fixes this.